### PR TITLE
Remove redefining include due to compilation error

### DIFF
--- a/i2c.c
+++ b/i2c.c
@@ -53,7 +53,6 @@ struct port_interface port_i2c = {
 /* To determine what functionality is present */
 #define I2C_FUNC_I2C 0x00000001
 #else
-#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #endif
 


### PR DESCRIPTION
cc -Wall -g   -c -o i2c.o i2c.c
In file included from i2c.c:57:0:
/usr/include/linux/i2c-dev.h:37:8: error: redefinition of ‘struct i2c_msg’
 struct i2c_msg {
        ^
In file included from i2c.c:56:0:
/usr/include/linux/i2c.h:68:8: note: originally defined here
 struct i2c_msg {
        ^
In file included from i2c.c:57:0:
/usr/include/linux/i2c-dev.h:89:7: error: redefinition of ‘union i2c_smbus_data’
 union i2c_smbus_data {
       ^
In file included from i2c.c:56:0:
/usr/include/linux/i2c.h:129:7: note: originally defined here
 union i2c_smbus_data {
       ^
<builtin>: recipe for target 'i2c.o' failed
make: *** [i2c.o] Error 1